### PR TITLE
Enhance CoSWID compliance

### DIFF
--- a/uswid/identity.py
+++ b/uswid/identity.py
@@ -95,8 +95,8 @@ class uSwidIdentity:
         except:
             return self.tag_id
 
-    # set tagid from a given bytes, if tagid is a valid UUID, we can
-    # just save the UUID in bytes in self.tag_id
+    # if tagid is a UUID in bytes, it tries to generate a string hex
+    # representation and save it in self.tag_id, otherwise plain tagid is saved
     def set_tagid(self, tagid):
         if type(tagid) is bytes:
             try:

--- a/uswid/identity.py
+++ b/uswid/identity.py
@@ -99,10 +99,11 @@ class uSwidIdentity:
     # representation and save it in self.tag_id, otherwise plain tagid is saved
     def set_tagid(self, tagid):
         if type(tagid) is bytes:
-            try:
-                self.tag_id = uuid.UUID(bytes=tagid).urn[9:]
-            except:
-                raise NotSupportedError("tagid is in bytes, but not parseable to a UUID")
+            if len(tagid) == 16:
+                hex_string = tagid.hex();
+                self.tag_id = str.format("{0}-{1}-{2}-{3}-{4}", hex_string[:8], hex_string[8:12], hex_string[12:16], hex_string[16:20], hex_string[20:32])
+            else:
+                raise NotSupportedError("tag-id is a byte array with length different than 16")
         elif type(tagid) is str:
             self.tag_id = tagid
         else:

--- a/uswid/test_uswid.py
+++ b/uswid/test_uswid.py
@@ -142,7 +142,7 @@ class TestSwidEntity(unittest.TestCase):
         xml = b"""<?xml version='1.0' encoding='UTF-8'?>
 <SoftwareIdentity name="DellBiosConnectNetwork"
 tagId="acbd84ff-9898-4922-8ade-dd4bbe2e40ba" tagVersion="1" version="1.5.2"
-versionScheme="unknown" xml:lang="en-us"
+versionScheme="semver" xml:lang="en-us"
 xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd"
 xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256"
 xmlns:SHA512="http://www.w3.org/2001/04/xmlenc#sha512"


### PR DESCRIPTION
I added some things to make python-uswid more CoSWID compliant, which in turn makes it compatible with [goswid](https://github.com/9elements/goswid).
- tag-ids are now represented as a 16 byte UUID in CBOR/CoSWID (if possible) and as a hex string representation for all other formats
- added the lang attribute to CBOR/CoSWID export
- added numeric representation of version-scheme for export in CBOR/CoSWID
- conform to 'one-or-more' CDDL rule in CoSWID
