### PR TITLE
Add Compiler Link type

### DIFF
--- a/uswid/link.py
+++ b/uswid/link.py
@@ -20,6 +20,7 @@ from .enums import uSwidGlobalMap
 
 class uSwidLinkRel(IntEnum):
     LICENSE = -2
+    COMPILER = -1
     ANCESTOR = 1
     COMPONENT = 2
     FEATURE = 3


### PR DESCRIPTION
I already accidently pushed the commit with License link type without making a pull request (I didn't even expect to actually be able to). If that commit is a problem, we can of course just revert that change.
But anyway.  I also added another link type, called compiler which is supposed to specify the compiler, with which the Software was compiled with (like GCC or clang). This patch is actually part of #37 