### PR TITLE
Print information on multiple tag IDs if encountered

### DIFF
--- a/uswid/container.py
+++ b/uswid/container.py
@@ -61,6 +61,10 @@ class uSwidContainer:
         """returns the existing identity, or creates one if none already exist"""
 
         if len(self._identities) > 1:
+            print("Found multiple tag IDs:", len(self._identities))
+            for identity in self._identities:
+                print("  -", identity.tag_id)
+
             return None
         if not self._identities:
             self._identities.append(uSwidIdentity())


### PR DESCRIPTION
It might make sense to save exports for multiple IDs; just store them as a list by default, maybe. Not sure what the goal is. :-)