### PR TITLE
Add support for LZMA payload compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,19 @@ If we are asked to process lots of different kinds of firmware, we do not always
 With this the SBoM builder tool does not know *where* the coSWID data starts in the blob, or *how many* coSWID sections there might be.
 If we include a small header with a 16 byte *magic* identifier then we can search the image to discover the offsets to read the coSWID blobs.
 
-The 24 byte uSWID header in full:
+The 25 byte uSWID header in full:
 
     uint8_t[16]   magic, "\x53\x42\x4F\x4D\xD6\xBA\x2E\xAC\xA3\xE6\x7A\x52\xAA\xEE\x3B\xAF"
-    uint8_t       header version, typically 0x02
-    uint16_t      little-endian header length, typically 0x17
+    uint8_t       header version, typically 0x03
+    uint16_t      little-endian header length, typically 0x19
     uint32_t      little-endian payload length
     uint8_t       flags
                     0x00: no flags set
-                    0x01: zlib compressed payload
+                    0x01: compressed payload
+    uint8_t       payload compression type
+                    0x00: none
+                    0x01: zlib
+                    0x02: lzma
 
 The uSWID header is automatically added when the file extension is `.uswid`, e.g.
 

--- a/docs/source/versionhistory.rst
+++ b/docs/source/versionhistory.rst
@@ -5,6 +5,10 @@ Version history
 
 This library adheres to `Semantic Versioning <http://semver.org/>`_.
 
+**0.4.7** (???)
+
+ - Add support for LZMA payload compression (Richard Hughes)
+
 **0.4.6** (2023-10-15)
 
  - Add SPDX export format (Richard Hughes)

--- a/uswid/__init__.py
+++ b/uswid/__init__.py
@@ -12,7 +12,13 @@ from uswid.payload import uSwidPayload
 from uswid.evidence import uSwidEvidence
 from uswid.identity import uSwidIdentity
 from uswid.entity import uSwidEntity, uSwidEntityRole
-from uswid.enums import uSwidGlobalMap, uSwidVersionScheme, USWID_HEADER_MAGIC
+from uswid.enums import (
+    uSwidGlobalMap,
+    uSwidVersionScheme,
+    uSwidHeaderFlags,
+    uSwidPayloadCompression,
+    USWID_HEADER_MAGIC,
+)
 from uswid.errors import NotSupportedError
 from uswid.format_coswid import uSwidFormatCoswid
 from uswid.format_goswid import uSwidFormatGoswid

--- a/uswid/cli.py
+++ b/uswid/cli.py
@@ -38,6 +38,7 @@ from uswid import (
     uSwidEntityRole,
     uSwidIdentity,
     uSwidVersionScheme,
+    uSwidPayloadCompression,
 )
 from uswid.format_coswid import uSwidFormatCoswid
 from uswid.format_ini import uSwidFormatIni
@@ -219,7 +220,7 @@ def _type_for_fmt(
     if fmt == SwidFormat.PKG_CONFIG:
         return uSwidFormatPkgconfig(filepath=filepath)
     if fmt == SwidFormat.USWID:
-        return uSwidFormatUswid(compress=args.compress)  # type: ignore
+        return uSwidFormatUswid(compression=args.compression)  # type: ignore
     return None
 
 
@@ -260,6 +261,14 @@ def main():
         dest="compress",
         default=False,
         action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--compression",
+        type=uSwidPayloadCompression.argparse,
+        choices=list(uSwidPayloadCompression),
+        dest="compression",
+        default=uSwidPayloadCompression.NONE,
         help="Compress uSWID containers",
     )
     parser.add_argument(
@@ -281,6 +290,11 @@ def main():
     if not load_filepaths:
         load_filepaths = []
     save_filepaths = args.save if args.save else []
+
+    # handle deprecated --compress
+    if args.compress:
+        print("WARNING: --compress is deprecated, please use --compression instead")
+        args.compression = uSwidPayloadCompression.ZLIB
 
     # deprecated arguments
     if args.binfile:

--- a/uswid/enums.py
+++ b/uswid/enums.py
@@ -82,4 +82,34 @@ class uSwidVersionScheme(IntEnum):
 
 USWID_HEADER_MAGIC = b"\x53\x42\x4F\x4D\xD6\xBA\x2E\xAC\xA3\xE6\x7A\x52\xAA\xEE\x3B\xAF"
 
+# deprecated
 USWID_HEADER_FLAG_COMPRESSED = 0x01
+
+
+class uSwidHeaderFlags(IntEnum):
+    """The header flags type"""
+
+    NONE = 0x00
+    COMPRESSED = 0x01
+
+
+class uSwidPayloadCompression(IntEnum):
+    """The payload compression type"""
+
+    NONE = 0
+    ZLIB = 1
+    LZMA = 2
+
+    def __str__(self):
+        return self.name.lower()
+
+    def __repr__(self):
+        return str(self)
+
+    @staticmethod
+    def argparse(s):
+        """Used only for argparse"""
+        try:
+            return uSwidPayloadCompression[s.upper()]
+        except KeyError:
+            return s


### PR DESCRIPTION
This is available by default in EDK2 firmware stacks, unlike zlib.