### PR TITLE
component: Do not crash on CycloneDX 1.4+ component types

### DIFF
--- a/uswid/format_cyclonedx.py
+++ b/uswid/format_cyclonedx.py
@@ -57,6 +57,36 @@ def _convert_str_to_version_scheme(version_scheme: str) -> uSwidVersionScheme:
     }.get(version_scheme, uSwidVersionScheme.UNKNOWN)
 
 
+def _convert_str_to_component_type(value: Optional[str]) -> uSwidComponentType:
+    """Map a CycloneDX component type to the nearest SWID component type.
+
+    CycloneDX 1.4+ defines component types (device-driver, framework,
+    operating-system, container, platform, file, cryptographic-asset, ...) that
+    have no native SWID/coSWID equivalent. Map each to the closest SWID type and
+    fall back to FIRMWARE for anything unknown, so a valid CycloneDX SBOM never
+    crashes the importer. (uSwidComponentType.from_str stays pure to the defined
+    SWID types.)
+    """
+    alias = {
+        "framework": "library",
+        "device-driver": "firmware",
+        "device": "firmware",
+        "platform": "firmware",
+        "operating-system": "application",
+        "container": "application",
+        "file": "library",
+        "cryptographic-asset": "library",
+        "machine-learning-model": "application",
+        "data": "library",
+    }
+    key = (value or "firmware").lower()
+    key = alias.get(key, key)
+    try:
+        return uSwidComponentType.from_str(key)
+    except KeyError:
+        return uSwidComponentType.FIRMWARE
+
+
 def _convert_entity_to_dict(entity: uSwidEntity) -> Dict[str, Any]:
     data: Dict[str, Any] = {}
     if entity.name:
@@ -113,7 +143,7 @@ class uSwidFormatCycloneDX(uSwidFormatBase):
         self, component: uSwidComponent, data: Dict[str, Any]
     ) -> None:
 
-        component.type = uSwidComponentType.from_str(data.get("type", "firmware"))
+        component.type = _convert_str_to_component_type(data.get("type"))
         component.persistent_id = data.get("group")
         component.cpe = data.get("cpe")
         component.software_name = data.get("name")

--- a/uswid/test_uswid.py
+++ b/uswid/test_uswid.py
@@ -27,7 +27,7 @@ from .errors import NotSupportedError
 from .link import uSwidLink, uSwidLinkRel
 from .entity import uSwidEntity, uSwidEntityRole
 from .enums import uSwidVersionScheme
-from .component import uSwidComponent
+from .component import uSwidComponent, uSwidComponentType
 from .hash import uSwidHash, uSwidHashAlg
 from .payload import uSwidPayload
 from .patch import uSwidPatch, uSwidPatchType
@@ -35,7 +35,7 @@ from .patch import uSwidPatch, uSwidPatchType
 from .format_ini import uSwidFormatIni
 from .format_coswid import uSwidFormatCoswid
 from .format_swid import uSwidFormatSwid
-from .format_cyclonedx import uSwidFormatCycloneDX
+from .format_cyclonedx import uSwidFormatCycloneDX, _convert_str_to_component_type
 from .format_spdx import uSwidFormatSpdx
 from .format_inf import uSwidFormatInf
 from .vcs import uSwidVcs
@@ -303,6 +303,53 @@ class TestSwidEntity(unittest.TestCase):
         self.assertEqual(
             uSwidVersionScheme.from_version("1.2.3-4~5"),
             uSwidVersionScheme.ALPHANUMERIC,
+        )
+
+    def test_component_type_from_str(self):
+        """SWID stringifier stays pure; CycloneDX type mapping lives in the loader"""
+
+        # uSwidComponentType.from_str: only the defined SWID types
+        self.assertEqual(
+            uSwidComponentType.from_str("firmware"), uSwidComponentType.FIRMWARE
+        )
+        self.assertEqual(
+            uSwidComponentType.from_str("application"), uSwidComponentType.APPLICATION
+        )
+        self.assertEqual(
+            uSwidComponentType.from_str("library"), uSwidComponentType.LIBRARY
+        )
+
+        # CycloneDX 1.4+ types are mapped to the nearest SWID type in the
+        # CycloneDX loader, and never crash the importer
+        self.assertEqual(
+            _convert_str_to_component_type("device-driver"), uSwidComponentType.FIRMWARE
+        )
+        self.assertEqual(
+            _convert_str_to_component_type("framework"), uSwidComponentType.LIBRARY
+        )
+        self.assertEqual(
+            _convert_str_to_component_type("operating-system"),
+            uSwidComponentType.APPLICATION,
+        )
+        self.assertEqual(
+            _convert_str_to_component_type("cryptographic-asset"),
+            uSwidComponentType.LIBRARY,
+        )
+        # native SWID types still resolve through the loader
+        self.assertEqual(
+            _convert_str_to_component_type("firmware"), uSwidComponentType.FIRMWARE
+        )
+        # matching is case-insensitive
+        self.assertEqual(
+            _convert_str_to_component_type("Device-Driver"), uSwidComponentType.FIRMWARE
+        )
+        # empty / unknown values fall back to FIRMWARE instead of raising
+        self.assertEqual(
+            _convert_str_to_component_type(""), uSwidComponentType.FIRMWARE
+        )
+        self.assertEqual(
+            _convert_str_to_component_type("totally-unknown"),
+            uSwidComponentType.FIRMWARE,
         )
 
     def test_container(self):


### PR DESCRIPTION
`uSwidFormatCycloneDX.load()` calls `uSwidComponentType.from_str(type)` for every component, but `from_str` did `uSwidComponentType[value.upper()]`, which raises `KeyError` for any CycloneDX type without a native SWID equivalent.

CycloneDX 1.4+ defines `device-driver`, `framework`, `operating-system`, `container`, `platform`, `file`, `cryptographic-asset`, and more. Every real UEFI firmware SBOM contains `device-driver` components, so importing one raised `KeyError: 'DEVICE-DRIVER'` and failed to load (found importing an edk2/OVMF SBOM with 102 device-driver modules).

This maps the CycloneDX-only types to the nearest SWID type (`device-driver`→`firmware`, `framework`→`library`, `operating-system`→`application`, …) and falls back to `FIRMWARE` for anything unknown, so a valid SBOM never crashes the importer. Includes a unit test covering native types, mapped types, and the unknown-value fallback.

The individual mappings are judgment calls — happy to adjust to your preference; the key behaviour is "don't crash on a valid CycloneDX type."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CycloneDX component-type handling during import.
  * Recognises native SWID and CycloneDX-specific component types, including case-insensitive values.
  * Applies sensible fallback handling for missing or unknown component types instead of reporting an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->