### PR TITLE
payload: fix --validate false positive for the SHA-256 hash check

### DIFF
--- a/uswid/payload.py
+++ b/uswid/payload.py
@@ -66,7 +66,7 @@ class uSwidPayload:
             problems += [
                 uSwidProblem("payload", f"No hashes in {self.name}", since="0.4.7")
             ]
-        if uSwidHashAlg.SHA256 not in self.hashes:
+        if uSwidHashAlg.SHA256 not in [ihash.alg_id for ihash in self.hashes]:
             problems += [
                 uSwidProblem("payload", f"No SHA256 hash in {self.name}", since="0.4.7")
             ]


### PR DESCRIPTION
## Problem
`uSwidPayload.problems()` tests `uSwidHashAlg.SHA256 not in self.hashes`, but `self.hashes` is a list of `uSwidHash` objects (no `__eq__`), so the membership test is **always true** — every payload, including ones carrying a valid SHA-256, is reported as `No SHA256 hash`.

## Fix
Compare against the algorithm IDs: `uSwidHashAlg.SHA256 not in [ihash.alg_id for ihash in self.hashes]`.

## Test
`problems()` returns `[]` for a payload with a valid SHA-256, and still flags a SHA-1-only payload. Full suite green (the two `test_vcs` / `test_format_inf` failures are pre-existing in this sandbox — they shell out to build a throwaway git repo — and are identical on `main`).

Small follow-on from #98.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SHA-256 payload validation to correctly verify the declared hashing algorithm.
  * Prevented valid payloads from being incorrectly rejected during hash verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->