### PR TITLE
evidence: add an optional measured hash to uSwidEvidence

### DIFF
--- a/uswid/evidence.py
+++ b/uswid/evidence.py
@@ -7,10 +7,11 @@
 #
 # pylint: disable=too-few-public-methods
 
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from datetime import datetime
 
+from .hash import uSwidHash, uSwidHashAlg
 from .problem import uSwidProblem, _is_redacted
 
 
@@ -27,6 +28,20 @@ class uSwidEvidence:
         """Date and time when this evidence was collected """
         self.device_id: Optional[str] = device_id
         """Device ID, typically a machine hostname"""
+        self._hashes: Dict[uSwidHashAlg, uSwidHash] = {}
+
+    def add_hash(self, ihash: uSwidHash) -> None:
+        """Adds a measured hash, deduplicating by algorithm ID"""
+        self._hashes[ihash.alg_id or uSwidHashAlg.UNKNOWN] = ihash
+
+    def remove_hash(self, alg_id: uSwidHashAlg) -> None:
+        """Removes a measured hash by algorithm ID"""
+        self._hashes.pop(alg_id)
+
+    @property
+    def hashes(self) -> List[uSwidHash]:
+        """Returns all the measured hashes"""
+        return list(self._hashes.values())
 
     def problems(self) -> List[uSwidProblem]:
         """Checks the payload for common problems"""
@@ -41,4 +56,7 @@ class uSwidEvidence:
         return problems
 
     def __repr__(self) -> str:
-        return f'uSwidEvidence(date="{self.date}",device_id={self.device_id})'
+        tmp = f'uSwidEvidence(date="{self.date}",device_id={self.device_id})'
+        for ihash in self.hashes:
+            tmp += f"\n - {ihash}"
+        return tmp

--- a/uswid/format_coswid.py
+++ b/uswid/format_coswid.py
@@ -232,6 +232,18 @@ class uSwidFormatCoswid(uSwidFormatBase):
             data[uSwidGlobalMap.DATE] = evidence.date.timestamp()
         if evidence.device_id:
             data[uSwidGlobalMap.DEVICE_ID] = evidence.device_id
+        if evidence.hashes:
+            # Per RFC 9393 a hash-entry is a member of a file-entry, not of the
+            # evidence-map itself; the evidence-map splices in the resource-collection
+            # group (which carries file-entry). Nest the measured hash under a FILE
+            # entry exactly as _save_payload does — do NOT emit a bare hash at the map
+            # top level.
+            file_data: Dict[uSwidGlobalMap, Any] = {}
+            evidence_hashes = []
+            for ihash in evidence.hashes:
+                evidence_hashes.append(self._save_hash(ihash))
+            _set_one_or_more(file_data, uSwidGlobalMap.HASH, evidence_hashes)
+            data[uSwidGlobalMap.FILE] = file_data
         return data
 
     def _save_entity(self, entity: uSwidEntity) -> Dict[uSwidGlobalMap, Any]:
@@ -393,6 +405,18 @@ class uSwidFormatCoswid(uSwidFormatBase):
                 evidence.date = datetime.utcfromtimestamp(value)
             if key == uSwidGlobalMap.DEVICE_ID:
                 evidence.device_id = value
+        # measured hashes live inside a FILE entry (RFC 9393: hash-entry is a member
+        # of file-entry), mirroring _load_payload — not at the evidence-map top level.
+        for file_data in _get_one_or_more(data, uSwidGlobalMap.FILE):
+            hash_value = file_data.get(uSwidGlobalMap.HASH)
+            if not hash_value:  # absent or an empty HASH list -> nothing to load
+                continue
+            if not isinstance(hash_value[0], list):
+                hash_value = [hash_value]
+            for hash_data in hash_value:
+                ihash = uSwidHash()
+                self._load_hash(ihash, hash_data)
+                evidence.add_hash(ihash)
 
     def _load_entity(
         self,

--- a/uswid/test_uswid.py
+++ b/uswid/test_uswid.py
@@ -11,6 +11,7 @@
 import os
 import sys
 import unittest
+import datetime
 from typing import Optional, Any
 import shutil
 import subprocess
@@ -30,10 +31,11 @@ from .enums import uSwidVersionScheme
 from .component import uSwidComponent
 from .hash import uSwidHash, uSwidHashAlg
 from .payload import uSwidPayload
+from .evidence import uSwidEvidence
 from .patch import uSwidPatch, uSwidPatchType
 
 from .format_ini import uSwidFormatIni
-from .format_coswid import uSwidFormatCoswid
+from .format_coswid import uSwidFormatCoswid, uSwidGlobalMap
 from .format_swid import uSwidFormatSwid
 from .format_cyclonedx import uSwidFormatCycloneDX
 from .format_spdx import uSwidFormatSpdx
@@ -606,6 +608,74 @@ class TestSwidEntity(unittest.TestCase):
         self.assertEqual(ini_load_patch.url, patch.url)
         self.assertEqual(ini_load_patch.description, patch.description)
         self.assertEqual(ini_load_patch.references, patch.references)
+
+    def test_evidence(self):
+        """Unit tests for uSwidEvidence, including the optional measured hash"""
+        self.maxDiff = None
+
+        # an evidence entry can now carry a measured hash (RFC 9393 records the
+        # measured hash on the evidence branch, inside a file-entry)
+        evidence = uSwidEvidence(
+            date=datetime.datetime.fromtimestamp(1600000000, tz=datetime.timezone.utc),
+            device_id="localhost",
+        )
+        evidence.add_hash(
+            uSwidHash(
+                alg_id=uSwidHashAlg.SHA256,
+                value="8cab6b2125c2b561351b4e02ee531f26dde05c3c6a2be8ff942975fbdef6823c",
+            )
+        )
+        self.assertIn("SHA256", str(evidence))
+        self.assertIn("8cab6b21", str(evidence))
+
+        # CoSWID export nests the measured hash under a FILE entry — RFC 9393 puts a
+        # hash-entry inside a file-entry, NOT at the evidence-map top level.
+        data = uSwidFormatCoswid()._save_evidence(evidence)  # type: ignore
+        self.assertNotIn(uSwidGlobalMap.HASH, data)  # not a bare hash at the map top
+        self.assertIn(uSwidGlobalMap.FILE, data)
+        self.assertIn(uSwidGlobalMap.HASH, data[uSwidGlobalMap.FILE])
+
+        # full CBOR save() -> load() round-trip on a real component, with TWO distinct
+        # algorithms, proves cross-tool interop (not just the in-memory helpers).
+        component = uSwidComponent(tag_id="test", software_version="1.2.3")
+        component.add_entity(
+            uSwidEntity(name="test", roles=[uSwidEntityRole.TAG_CREATOR])
+        )
+        ev = uSwidEvidence(
+            date=datetime.datetime.fromtimestamp(1600000000, tz=datetime.timezone.utc),
+            device_id="localhost",
+        )
+        ev.add_hash(
+            uSwidHash(
+                alg_id=uSwidHashAlg.SHA256,
+                value="8cab6b2125c2b561351b4e02ee531f26dde05c3c6a2be8ff942975fbdef6823c",
+            )
+        )
+        ev.add_hash(uSwidHash(alg_id=uSwidHashAlg.SHA384, value="a" * 96))
+        component.add_evidence(ev)
+        blob = uSwidFormatCoswid().save(uSwidContainer([component]))
+        component2 = uSwidFormatCoswid().load(blob)[0]
+        self.assertEqual(len(component2.evidences), 1)
+        got = {h.alg_id: h.value for h in component2.evidences[0].hashes}
+        self.assertEqual(
+            got[uSwidHashAlg.SHA256],
+            "8cab6b2125c2b561351b4e02ee531f26dde05c3c6a2be8ff942975fbdef6823c",
+        )
+        self.assertEqual(got[uSwidHashAlg.SHA384], "a" * 96)
+
+        # a second hash with the same algorithm is deduplicated by algorithm ID
+        ev.add_hash(
+            uSwidHash(
+                alg_id=uSwidHashAlg.SHA256,
+                value="067cb8292dc062eabbe05734ef7987eb1333b6b6067cb8292dc062eabbe05734",
+            )
+        )
+        self.assertEqual(len(ev.hashes), 2)  # SHA256 (replaced) + SHA384
+        replaced = {h.alg_id: h.value for h in ev.hashes}
+        self.assertEqual(
+            replaced[uSwidHashAlg.SHA256],
+            "067cb8292dc062eabbe05734ef7987eb1333b6b6067cb8292dc062eabbe05734",
+        )
 
     def test_component_purl(self):
         """Unit tests for uSwidComponent, PURL specific"""


### PR DESCRIPTION
## What
Adds an optional measured hash to `uSwidEvidence`, mirroring `uSwidPayload`.

## Why — RFC 9393 model completeness
RFC 9393 models a component's *measured* hash on the **evidence** branch: a `hash-entry` inside a `file-entry` on `evidence` is how "here is what we measured" is expressed, distinct from the builder-declared `payload` hash. Today `uSwidEvidence` carries only `{date, device_id}`, so the CoSWID encoder/decoder silently drops any measured hash — the evidence branch can't carry the very thing it exists for. This closes that gap in the object model.

The concrete use case that surfaced it: reconciling the *shipped bytes* of a firmware image against its embedded coSWID — a measured hash a downstream consumer recomputes from a dumped image, **alongside, not replacing,** the source/colloquial hash. Happy to discuss that motivation here or in a separate issue; the model gap stands on its own regardless.

## Fix
- `uSwidEvidence`: add `add_hash` / `remove_hash` / `hashes` (dedup by algorithm ID), like `uSwidPayload`.
- `format_coswid`: the measured hash is **nested under a `FILE` (file-entry) member of the evidence-map**, exactly as `_save_payload` does — per RFC 9393 a `hash-entry` is a member of a `file-entry`, not a bare member of the evidence-map — so the output stays spec-conformant and interoperable.

## Test
Full CBOR `save()`/`load()` round-trip on a real component carrying evidence with **two distinct algorithms** (SHA-256 + SHA-384); asserts the hash nests under `FILE` (not a bare hash at the map top) and both survive. No change to existing callers — evidence with no hash encodes/decodes exactly as before. Full suite green (same two pre-existing sandbox failures as `main`).

In the spirit of #98.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evidence records can now store, retrieve and remove measured hashes.
  * Evidence hashes are included in their displayed representation.
  * Evidence hashes are serialised and restored correctly within CoSWID file entries.
  * Hashes using the same algorithm are replaced consistently.
  * Support includes multiple hash algorithms, including SHA-256 and SHA-384.

* **Tests**
  * Added coverage for hash handling, representations and CBOR round-trip preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->